### PR TITLE
Storage -> global speed optimization

### DIFF
--- a/app/assets/javascripts/contacts/index/contact.es6
+++ b/app/assets/javascripts/contacts/index/contact.es6
@@ -5,13 +5,13 @@ class Contact extends React.Component {
     super(props)
 
     this.state = {
-      selected: this.props.contact.selected
+      selected: this.props.selected
     }
   }
 
   componentWillReceiveProps(newProps) {
-    if(newProps.contact.selected != this.state.selected) {
-      this.setState({ selected: newProps.contact.selected })
+    if(newProps.selected != this.state.selected) {
+      this.setState({ selected: newProps.selected })
     }
   }
 

--- a/app/assets/javascripts/contacts/index/contacts.es6
+++ b/app/assets/javascripts/contacts/index/contacts.es6
@@ -43,12 +43,15 @@ class Contacts extends React.Component {
 
   renderContacts() {
     return _.map(this.props.contacts, (contact) => {
+      var selected = _.includes(this.props.selectedItemIds, contact.id)
+
       return (
         <Contact key={contact.id}
                  permissions={this.props.permissions}
                  contact={contact}
                  search={this.props.search}
                  tagOptionsPath={this.props.tagOptionsPath}
+                 selected={selected}
                  updateSelected={this.props.updateSelected}
                  pushTagIdsFilter={this.props.pushTagIdsFilter}
                  pushFieldIdsFilter={this.props.pushFieldIdsFilter} />

--- a/app/assets/javascripts/contacts/main.es6
+++ b/app/assets/javascripts/contacts/main.es6
@@ -18,12 +18,12 @@ class Main extends BaseMain {
     this.exportUrl      = `${this.props.route.contactsPath}/export`
 
     this.state = {
-      contacts:           [],
-      filteredContactIds: [],
-      filteredCount:      0,
-      selectedContactIds: [],
-      selectedCount:      0,
-      loaded:             false,
+      items:           [],
+      filteredItemIds: [],
+      filteredCount:   0,
+      selectedItemIds: [],
+      selectedCount:   0,
+      loaded:          false,
     }
   }
 
@@ -44,36 +44,30 @@ class Main extends BaseMain {
     }
   }
 
-  updateSelected(contact, newValue) {
-    var index    = _.findIndex(this.state.contacts, (c) => { return contact.id == c.id })
-    var contacts = this.state.contacts
+  updateSelected(item, newValue) {
+    var index    = _.findIndex(this.state.items, (i) => { return item.id == i.id })
+    var items = this.state.items
 
-    contacts[index].selected = newValue
+    items[index].selected = newValue
 
     var selectedCount = newValue ? this.state.selectedCount + 1 : this.state.selectedCount - 1
 
     this.setState({
-      contacts:      contacts,
+      items:         items,
       selectedCount: selectedCount
     })
   }
 
-  unselectAllContacts() {
-    var contacts = this.state.contacts
+  unselectAllItems() {
+    var items = this.state.items
 
-    _.each(contacts, (contact) => {
-      contact.selected = false
+    _.each(items, (item) => {
+      item.selected = false
     })
 
     this.setState({
-      contacts:      contacts,
+      items:         items,
       selectedCount: 0
-    })
-  }
-
-  filteredContacts() {
-    return _.filter(this.state.contacts, (contact) => {
-      return _.includes(this.state.filteredContactIds, contact.id)
     })
   }
 
@@ -82,22 +76,22 @@ class Main extends BaseMain {
     return (
       <QuickSearch title={this.title}
                    loaded={this.state.loaded}
-                   results={this.state.contacts.length}
+                   results={this.state.filteredItemIds.length}
                    quickSearch={filters.quickSearch}
                    updateQuickSearch={this.updateQuickSearch.bind(this)}
                    filters={filters}
                    exportUrl={this.exportUrl}
                    selectedCount={this.state.selectedCount}
-                   contacts={this.state.contacts}
+                   contacts={this.filteredItems()}
                    tagOptionsPath={this.props.route.tagOptionsPath}
-                   unselectAllContacts={this.unselectAllContacts.bind(this)} />
+                   unselectAllContacts={this.unselectAllItems.bind(this)} />
     )
   }
 
   renderItems() {
     return (
       <Contacts permissions={this.props.route.permissions}
-                contacts={this.filteredContacts()}
+                contacts={this.filteredItems()}
                 loaded={this.state.loaded}
                 search={this.props.location.search}
                 tagOptionsPath={this.props.route.tagOptionsPath}
@@ -109,12 +103,12 @@ class Main extends BaseMain {
   }
 
   renderItem() {
-    var urlContactId = parseInt(this.props.params.id)
-    var contact      = _.find(this.state.contacts, (contact) => { return contact.id == urlContactId } )
+    var urlItemId = parseInt(this.props.params.id)
+    var item      = _.find(this.state.items, (item) => { return item.id == urlItemId } )
 
     return (
-      <Contact id={urlContactId}
-               contact={contact}
+      <Contact id={urlItemId}
+               contact={item}
                permissions={this.props.route.permissions}
                currentUserId={this.props.route.currentUserId}
                labId={this.props.route.labId}
@@ -127,7 +121,7 @@ class Main extends BaseMain {
                organizationOptionsPath={this.props.route.organizationOptionsPath}
                projectOptionsPath={this.props.route.projectOptionsPath}
                eventOptionsPath={this.props.route.eventOptionsPath}
-               contacts={this.state.contacts}
+               contacts={this.filteredItems()}
                router={this.props.router} />
     )
   }

--- a/app/assets/javascripts/contacts/main.es6
+++ b/app/assets/javascripts/contacts/main.es6
@@ -18,9 +18,12 @@ class Main extends BaseMain {
     this.exportUrl      = `${this.props.route.contactsPath}/export`
 
     this.state = {
-      contacts:      [],
-      loaded:        false,
-      selectedCount: 0,
+      contacts:           [],
+      filteredContactIds: [],
+      filteredCount:      0,
+      selectedContactIds: [],
+      selectedCount:      0,
+      loaded:             false,
     }
   }
 
@@ -68,6 +71,12 @@ class Main extends BaseMain {
     })
   }
 
+  filteredContacts() {
+    return _.filter(this.state.contacts, (contact) => {
+      return _.includes(this.state.filteredContactIds, contact.id)
+    })
+  }
+
   // @overrides
   renderQuickSearch(filters) {
     return (
@@ -88,7 +97,7 @@ class Main extends BaseMain {
   renderItems() {
     return (
       <Contacts permissions={this.props.route.permissions}
-                contacts={this.state.contacts}
+                contacts={this.filteredContacts()}
                 loaded={this.state.loaded}
                 search={this.props.location.search}
                 tagOptionsPath={this.props.route.tagOptionsPath}

--- a/app/assets/javascripts/contacts/main.es6
+++ b/app/assets/javascripts/contacts/main.es6
@@ -42,7 +42,7 @@ class Main extends BaseMain {
   }
 
   updateSelected(contact, newValue) {
-    var index    = _.findIndex(this.state.contacts, (c) => { return contact.id == c.id})
+    var index    = _.findIndex(this.state.contacts, (c) => { return contact.id == c.id })
     var contacts = this.state.contacts
 
     contacts[index].selected = newValue

--- a/app/assets/javascripts/contacts/main.es6
+++ b/app/assets/javascripts/contacts/main.es6
@@ -45,29 +45,24 @@ class Main extends BaseMain {
   }
 
   updateSelected(item, newValue) {
-    var index    = _.findIndex(this.state.items, (i) => { return item.id == i.id })
-    var items = this.state.items
-
-    items[index].selected = newValue
-
-    var selectedCount = newValue ? this.state.selectedCount + 1 : this.state.selectedCount - 1
-
-    this.setState({
-      items:         items,
-      selectedCount: selectedCount
-    })
+    if(newValue == false && _.includes(this.state.selectedItemIds, item.id)) {
+      this.setState({
+        selectedItemIds: _.filter(this.state.selectedItemIds, (itemId) => { return itemId != item.id }),
+        selectedCount:   this.state.selectedCount - 1,
+      })
+    }
+    else if(newValue == true && !_.includes(this.state.selectedItemIds, item.id)) {
+      this.setState({
+        selectedItemIds: this.state.selectedItemIds.concat([item.id]),
+        selectedCount:   this.state.selectedCount + 1,
+      })
+    }
   }
 
   unselectAllItems() {
-    var items = this.state.items
-
-    _.each(items, (item) => {
-      item.selected = false
-    })
-
     this.setState({
-      items:         items,
-      selectedCount: 0
+      selectedItemIds: [],
+      selectedCount:   0,
     })
   }
 
@@ -76,12 +71,12 @@ class Main extends BaseMain {
     return (
       <QuickSearch title={this.title}
                    loaded={this.state.loaded}
-                   results={this.state.filteredItemIds.length}
+                   results={this.state.filteredCount}
+                   selectedCount={this.state.selectedCount}
                    quickSearch={filters.quickSearch}
                    updateQuickSearch={this.updateQuickSearch.bind(this)}
                    filters={filters}
                    exportUrl={this.exportUrl}
-                   selectedCount={this.state.selectedCount}
                    contacts={this.filteredItems()}
                    tagOptionsPath={this.props.route.tagOptionsPath}
                    unselectAllContacts={this.unselectAllItems.bind(this)} />
@@ -92,6 +87,7 @@ class Main extends BaseMain {
     return (
       <Contacts permissions={this.props.route.permissions}
                 contacts={this.filteredItems()}
+                selectedItemIds={this.state.selectedItemIds}
                 loaded={this.state.loaded}
                 search={this.props.location.search}
                 tagOptionsPath={this.props.route.tagOptionsPath}

--- a/app/assets/javascripts/contacts/show/contact.es6
+++ b/app/assets/javascripts/contacts/show/contact.es6
@@ -31,6 +31,10 @@ class Contact extends React.Component {
     this.bindCable()
   }
 
+  componentWillUnmount() {
+    this.unbindCable()
+  }
+
   componentDidUpdate(prevProps) {
     if(prevProps.id != this.props.id) {
       if(this.state.contact == undefined) {
@@ -47,7 +51,7 @@ class Contact extends React.Component {
   }
 
   bindCable() {
-    App.cable.subscriptions.create({ channel: "ContactsChannel", lab_id: this.props.labId }, {
+    this.cableSubscription = App.cable.subscriptions.create({ channel: "ContactsChannel", lab_id: this.props.labId }, {
       received: (data) => {
         var camelData = humps.camelizeKeys(data)
         var itemId    = camelData.action == 'destroy' ? camelData.itemId : camelData.item.id
@@ -62,6 +66,10 @@ class Contact extends React.Component {
         }
       }
     })
+  }
+
+  unbindCable() {
+    App.cable.subscriptions.remove(this.cableSubscription)
   }
 
   contactPath() {

--- a/app/assets/javascripts/events/main.es6
+++ b/app/assets/javascripts/events/main.es6
@@ -16,8 +16,12 @@ class Main extends BaseMain {
     this.AdvancedSearch = AdvancedSearch
 
     this.state = {
-      events: [],
-      loaded: false
+      items:           [],
+      filteredItemIds: [],
+      filteredCount:   0,
+      selectedItemIds: [],
+      selectedCount:   0,
+      loaded:          false,
     }
   }
 
@@ -34,7 +38,8 @@ class Main extends BaseMain {
 
   renderItems() {
     return (
-      <Events events={this.state.events}
+      <Events permissions={this.props.route.permissions}
+              events={this.filteredItems()}
               loaded={this.state.loaded}
               search={this.props.location.search}
               loadingImagePath={this.props.route.loadingImagePath} />
@@ -56,7 +61,7 @@ class Main extends BaseMain {
              search={this.props.location.search}
              loadingImagePath={this.props.route.loadingImagePath}
              contactOptionsPath={this.props.route.contactOptionsPath}
-             events={this.state.events}
+             events={this.filteredItems()}
              router={this.props.router} />
     )
   }

--- a/app/assets/javascripts/events/show/event.es6
+++ b/app/assets/javascripts/events/show/event.es6
@@ -27,6 +27,10 @@ class Event extends React.Component {
     this.bindCable()
   }
 
+  componentWillUnmount() {
+    this.unbindCable()
+  }
+
   componentDidUpdate(prevProps) {
     if(prevProps.id != this.props.id) {
       if(this.state.event == undefined) {
@@ -43,7 +47,7 @@ class Event extends React.Component {
   }
 
   bindCable() {
-    App.cable.subscriptions.create({ channel: "EventsChannel", lab_id: this.props.labId }, {
+    this.cableSubscription = App.cable.subscriptions.create({ channel: "EventsChannel", lab_id: this.props.labId }, {
       received: (data) => {
         var camelData = humps.camelizeKeys(data)
         var itemId    = camelData.action == 'destroy' ? camelData.itemId : camelData.item.id
@@ -58,6 +62,10 @@ class Event extends React.Component {
         }
       }
     })
+  }
+
+  unbindCable() {
+    App.cable.subscriptions.remove(this.cableSubscription)
   }
 
   eventPath() {

--- a/app/assets/javascripts/organizations/main.es6
+++ b/app/assets/javascripts/organizations/main.es6
@@ -17,8 +17,12 @@ class Main extends BaseMain {
     this.exportUrl      = `${this.props.route.organizationsPath}/export`
 
     this.state = {
-      organizations: [],
-      loaded:        false,
+      items:           [],
+      filteredItemIds: [],
+      filteredCount:   0,
+      selectedItemIds: [],
+      selectedCount:   0,
+      loaded:          false,
     }
   }
 
@@ -36,7 +40,8 @@ class Main extends BaseMain {
 
   renderItems() {
     return (
-      <Organizations organizations={this.state.organizations}
+      <Organizations permissions={this.props.route.permissions}
+                     organizations={this.filteredItems()}
                      loaded={this.state.loaded}
                      search={this.props.location.search}
                      loadingImagePath={this.props.route.loadingImagePath} />
@@ -58,7 +63,7 @@ class Main extends BaseMain {
                     search={this.props.location.search}
                     loadingImagePath={this.props.route.loadingImagePath}
                     contactOptionsPath={this.props.route.contactOptionsPath}
-                    organizations={this.state.organizations}
+                    organizations={this.filteredItems()}
                     router={this.props.router} />
     )
   }

--- a/app/assets/javascripts/organizations/show/organization.es6
+++ b/app/assets/javascripts/organizations/show/organization.es6
@@ -27,6 +27,10 @@ class Organization extends React.Component {
     this.bindCable()
   }
 
+  componentWillUnmount() {
+    this.unbindCable()
+  }
+
   componentDidUpdate(prevProps) {
     if(prevProps.id != this.props.id) {
       if(this.state.organization == undefined) {
@@ -43,7 +47,7 @@ class Organization extends React.Component {
   }
 
   bindCable() {
-    App.cable.subscriptions.create({ channel: "OrganizationsChannel", lab_id: this.props.labId }, {
+    this.cableSubscription =  App.cable.subscriptions.create({ channel: "OrganizationsChannel", lab_id: this.props.labId }, {
       received: (data) => {
         var camelData = humps.camelizeKeys(data)
         var itemId    = camelData.action == 'destroy' ? camelData.itemId : camelData.item.id
@@ -58,6 +62,10 @@ class Organization extends React.Component {
         }
       }
     })
+  }
+
+  unbindCable() {
+    App.cable.subscriptions.remove(this.cableSubscription)
   }
 
   organizationPath() {

--- a/app/assets/javascripts/projects/main.es6
+++ b/app/assets/javascripts/projects/main.es6
@@ -16,8 +16,12 @@ class Main extends BaseMain {
     this.AdvancedSearch = AdvancedSearch
 
     this.state = {
-      projects: [],
-      loaded:   false,
+      items:           [],
+      filteredItemIds: [],
+      filteredCount:   0,
+      selectedItemIds: [],
+      selectedCount:   0,
+      loaded:          false,
     }
   }
 
@@ -33,7 +37,8 @@ class Main extends BaseMain {
 
   renderItems() {
     return (
-      <Projects projects={this.state.projects}
+      <Projects permissions={this.props.route.permissions}
+                projects={this.filteredItems()}
                 loaded={this.state.loaded}
                 search={this.props.location.search}
                 loadingImagePath={this.props.route.loadingImagePath} />
@@ -55,7 +60,7 @@ class Main extends BaseMain {
                search={this.props.location.search}
                loadingImagePath={this.props.route.loadingImagePath}
                contactOptionsPath={this.props.route.contactOptionsPath}
-               projects={this.state.projects}
+               projects={this.filteredItems()}
                router={this.props.router} />
     )
   }

--- a/app/assets/javascripts/projects/show/project.es6
+++ b/app/assets/javascripts/projects/show/project.es6
@@ -27,6 +27,10 @@ class Project extends React.Component {
     this.bindCable()
   }
 
+  componentWillUnmount() {
+    this.unbindCable()
+  }
+
   componentDidUpdate(prevProps) {
     if(prevProps.id != this.props.id) {
       if(this.state.project == undefined) {
@@ -43,7 +47,7 @@ class Project extends React.Component {
   }
 
   bindCable() {
-    App.cable.subscriptions.create({ channel: "ProjectsChannel", lab_id: this.props.labId }, {
+    this.cableSubscription = App.cable.subscriptions.create({ channel: "ProjectsChannel", lab_id: this.props.labId }, {
       received: (data) => {
         var camelData = humps.camelizeKeys(data)
         var itemId    = camelData.action == 'destroy' ? camelData.itemId : camelData.item.id
@@ -58,6 +62,10 @@ class Project extends React.Component {
         }
       }
     })
+  }
+
+  unbindCable() {
+    App.cable.subscriptions.remove(this.cableSubscription)
   }
 
   projectPath() {

--- a/app/assets/javascripts/routes.es6
+++ b/app/assets/javascripts/routes.es6
@@ -1,15 +1,61 @@
 import { createHistory }                from 'history'
 import { useRouterHistory, withRouter } from 'react-router'
 
+import Storage       from './storage.es6'
+
 import Contacts      from './contacts/main.es6'
 import Organizations from './organizations/main.es6'
 import Projects      from './projects/main.es6'
 import Events        from './events/main.es6'
 
-var ContactsWithRouter      = withRouter(Contacts)
-var OrganizationsWithRouter = withRouter(Organizations)
-var ProjectsWithRouter      = withRouter(Projects)
-var EventsWithRouter        = withRouter(Events)
+class Dispatcher extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.storage = new Storage(this.props)
+  }
+
+  render() {
+    if(this.props.params.itemType == 'contacts') {
+      return(
+        <Contacts route={this.props.route}
+                  router={this.props.router}
+                  location={this.props.location}
+                  params={this.props.params}
+                  storage={this.storage} />
+      )
+    }
+    else if(this.props.params.itemType == 'organizations') {
+      return(
+        <Organizations route={this.props.route}
+                       router={this.props.router}
+                       location={this.props.location}
+                       params={this.props.params}
+                       storage={this.storage} />
+      )
+    }
+    else if(this.props.params.itemType == 'projects') {
+      return(
+        <Projects route={this.props.route}
+                  router={this.props.router}
+                  location={this.props.location}
+                  params={this.props.params}
+                  storage={this.storage} />
+      )
+    }
+    else if(this.props.params.itemType == 'events') {
+      return(
+        <Events route={this.props.route}
+                router={this.props.router}
+                location={this.props.location}
+                params={this.props.params}
+                storage={this.storage} />
+      )
+    }
+  }
+}
+
+var DispatcherWithRouter = withRouter(Dispatcher)
 
 class Routes extends React.Component {
   componentWillMount() {
@@ -17,59 +63,30 @@ class Routes extends React.Component {
       basename: this.props.labPath
     })
 
-    global.browserHistory = this.browserHistory;
+    global.browserHistory = this.browserHistory
   }
 
   render() {
     return (
       <Router history={this.browserHistory}>
-        <Route path="/contacts" component={ContactsWithRouter}
+        <Route path=":itemType" component={DispatcherWithRouter}
                                 permissions={this.props.permissions}
                                 currentUserId={this.props.currentUserId}
                                 labId={this.props.labId}
                                 contactsPath={this.props.contactsPath}
+                                organizationsPath={this.props.organizationsPath}
+                                projectsPath={this.props.projectsPath}
+                                eventsPath={this.props.eventsPath}
+                                contactOptionsPath={this.props.contactOptionsPath}
                                 organizationOptionsPath={this.props.organizationOptionsPath}
                                 projectOptionsPath={this.props.projectOptionsPath}
                                 eventOptionsPath={this.props.eventOptionsPath}
                                 tagOptionsPath={this.props.tagOptionsPath}
                                 fieldOptionsPath={this.props.fieldOptionsPath}
+                                organizationStatusesOptionsPath={this.props.organizationStatusesOptionsPath}
                                 loadingImagePath={this.props.loadingImagePath}>
 
-          <Route path=":id" component={ContactsWithRouter} />
-        </Route>
-
-        <Route path="/organizations" component={OrganizationsWithRouter}
-                                     permissions={this.props.permissions}
-                                     currentUserId={this.props.currentUserId}
-                                     labId={this.props.labId}
-                                     organizationsPath={this.props.organizationsPath}
-                                     contactOptionsPath={this.props.contactOptionsPath}
-                                     loadingImagePath={this.props.loadingImagePath}
-                                     organizationStatusesOptionsPath={this.props.organizationStatusesOptionsPath}>
-
-          <Route path=":id" component={OrganizationsWithRouter} />
-        </Route>
-
-        <Route path="/projects" component={ProjectsWithRouter}
-                                permissions={this.props.permissions}
-                                currentUserId={this.props.currentUserId}
-                                labId={this.props.labId}
-                                projectsPath={this.props.projectsPath}
-                                contactOptionsPath={this.props.contactOptionsPath}
-                                loadingImagePath={this.props.loadingImagePath}>
-
-          <Route path=":id" component={ProjectsWithRouter} />
-        </Route>
-
-        <Route path="/events" component={EventsWithRouter}
-                              permissions={this.props.permissions}
-                              currentUserId={this.props.currentUserId}
-                              labId={this.props.labId}
-                              eventsPath={this.props.eventsPath}
-                              contactOptionsPath={this.props.contactOptionsPath}
-                              loadingImagePath={this.props.loadingImagePath}>
-
-          <Route path=":id" component={EventsWithRouter} />
+          <Route path=":id" component={DispatcherWithRouter} />
         </Route>
       </Router>
     )

--- a/app/assets/javascripts/shared/base/base_main.es6
+++ b/app/assets/javascripts/shared/base/base_main.es6
@@ -125,8 +125,8 @@ class BaseMain extends React.Component {
         items:           items,
         filteredItemIds: _.map(items, 'id'),
         filteredCount:   items.length,
-        //selectedItemIds: [],
-        //selectedCount:   0,
+        //selectedItemIds: [], => keep selected items
+        //selectedCount:   0,  => keep selected items
         loaded:          true,
       }, () => {
         this.props.storage.setItem(`${this.itemType}s`, items)

--- a/app/assets/javascripts/storage.es6
+++ b/app/assets/javascripts/storage.es6
@@ -5,11 +5,6 @@ class Storage {
     this.route    = props.route
     this.ee       = new EventEmitter()
 
-    // this.contacts      = []
-    // this.organizations = []
-    // this.projects      = []
-    // this.events        = []
-
     this.bindCable('contact')
     this.bindCable('organization')
     this.bindCable('project')
@@ -39,9 +34,7 @@ class Storage {
   onCableUpdate(data, itemType, itemId) {
     var items             = this[`${itemType}s`]
     var index             = _.findIndex(items, (item) => { return itemId == item.id })
-    var wasSelected       = items[index].selected
     items[index]          = data.item
-    items[index].selected = wasSelected // to keep selection when updated (only useful for contacts for now)
 
     this.ee.emitEvent(`${itemType}-updated`) // signal component that state need to be updated from storage
   }

--- a/app/assets/javascripts/storage.es6
+++ b/app/assets/javascripts/storage.es6
@@ -32,11 +32,14 @@ class Storage {
   }
 
   onCableUpdate(data, itemType, itemId) {
-    var items             = this[`${itemType}s`]
-    var index             = _.findIndex(items, (item) => { return itemId == item.id })
-    items[index]          = data.item
+    var items    = this[`${itemType}s`]
+    var index    = _.findIndex(items, (item) => { return itemId == item.id })
 
-    this.ee.emitEvent(`${itemType}-updated`) // signal component that state need to be updated from storage
+    if(index != -1) {
+      items[index] = data.item
+
+      this.ee.emitEvent(`${itemType}-updated`) // signal component that state need to be updated from storage
+    }
   }
 
   onCableDestroy(data, itemType, itemId) {

--- a/app/assets/javascripts/storage.es6
+++ b/app/assets/javascripts/storage.es6
@@ -1,0 +1,65 @@
+import  EventEmitter from 'wolfy87-eventemitter'
+
+class Storage {
+  constructor(props) {
+    this.route    = props.route
+    this.ee       = new EventEmitter()
+
+    // this.contacts      = []
+    // this.organizations = []
+    // this.projects      = []
+    // this.events        = []
+
+    this.bindCable('contact')
+    this.bindCable('organization')
+    this.bindCable('project')
+    this.bindCable('event')
+  }
+
+  bindCable(itemType) {
+    App.cable.subscriptions.create({ channel: `${_.upperFirst(itemType)}sChannel`, lab_id: this.route.labId }, {
+      received: (data) => {
+        var camelData = humps.camelizeKeys(data)
+        var itemId    = camelData.action == 'destroy' ? camelData.itemId : camelData.item.id
+
+        if(camelData.action == 'create')
+          this.onCableCreate(camelData, itemType, itemId)
+        else if(camelData.action == 'update')
+          this.onCableUpdate(camelData, itemType, itemId)
+        else if(camelData.action == 'destroy')
+          this.onCableDestroy(camelData, itemType, itemId)
+      }
+    })
+  }
+
+  onCableCreate(data, itemType, itemId) {
+    this.ee.emitEvent(`${itemType}-created`) // signal component that state need to be reloaded from backend
+  }
+
+  onCableUpdate(data, itemType, itemId) {
+    var items             = this[`${itemType}s`]
+    var index             = _.findIndex(items, (item) => { return itemId == item.id })
+    var wasSelected       = items[index].selected
+    items[index]          = data.item
+    items[index].selected = wasSelected // to keep selection when updated (only useful for contacts for now)
+
+    this.ee.emitEvent(`${itemType}-updated`) // signal component that state need to be updated from storage
+  }
+
+  onCableDestroy(data, itemType, itemId) {
+    var items            = this[`${itemType}s`]
+    this[`${itemType}s`] = _.filter(items, (item) => { return itemId != item.id })
+
+    this.ee.emitEvent(`${itemType}-destroyed`) // signal component that state need to be updated from storage
+  }
+
+  getItem(name) {
+    return this[name]
+  }
+
+  setItem(name, newItem) {
+    this[name] = newItem
+  }
+}
+
+module.exports = Storage

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -11,9 +11,15 @@ class ContactsController < ApplicationController
             :lab_id => @lab.id
           })).run
 
-          render :json => {
-            :contacts => contacts
-          }
+          if params[:only_ids]
+            render :json => {
+              :contact_ids => contacts
+            }
+          else
+            render :json => {
+              :contacts => contacts
+            }
+          end
         else
           render_permission_error
         end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,9 +11,15 @@ class EventsController < ApplicationController
             :lab_id => @lab.id
           })).run
 
-          render :json => {
-            :events => events
-          }
+          if params[:only_ids]
+            render :json => {
+              :event_ids => events
+            }
+          else
+            render :json => {
+              :events => events
+            }
+          end
         else
           render_permission_error
         end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -11,9 +11,15 @@ class OrganizationsController < ApplicationController
             :lab_id => @lab.id
           })).run
 
-          render :json => {
-            :organizations => organizations
-          }
+          if params[:only_ids]
+            render :json => {
+              :organization_ids => organizations
+            }
+          else
+            render :json => {
+              :organizations => organizations
+            }
+          end
         else
           render_permission_error
         end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,9 +11,15 @@ class ProjectsController < ApplicationController
             :lab_id => @lab.id
           })).run
 
-          render :json => {
-            :projects => projects
-          }
+          if params[:only_ids]
+            render :json => {
+              :project_ids => projects
+            }
+          else
+            render :json => {
+              :projects => projects
+            }
+          end
         else
           render_permission_error
         end

--- a/app/searches/base_search.rb
+++ b/app/searches/base_search.rb
@@ -10,8 +10,13 @@ class BaseSearch
   end
 
   def run
-    results = run_step.results.collect(&:_source)
-    self.class.reject_private_notes_from_collection(results, user)
+    if params[:only_ids]
+      # we only get meta informations when fetching ids => http://stackoverflow.com/a/17497442/1243212
+      results = run_step.results.results.collect(&:_id).collect(&:to_i)
+    else
+      results = run_step.results.collect(&:_source)
+      self.class.reject_private_notes_from_collection(results, user)
+    end
   end
 
   def self.reject_private_notes_from_collection(results, user)
@@ -51,6 +56,12 @@ class BaseSearch
       'from' => params[:offset].to_i,
       'size' => STEP
     }
+
+    if params[:only_ids]
+      options = options.merge({
+        'fields' => []
+      })
+    end
 
     options
   end

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -76,6 +76,8 @@ namespace :app do
     gastro.organizations.create!(name: "Creative Wallonia")
     gastro.organizations.create!(name: "80LIMIT")
     gastro.organizations.create!(name: "Phonoid")
+
+    Sidekiq::Queue.new.clear
   end
 
   task :bootstrap_fake => :environment do
@@ -193,5 +195,7 @@ namespace :app do
                                 :field_type => :enum,
                                 :options    => ['Homme', 'Femme'])
     end
+
+    Sidekiq::Queue.new.clear
   end
 end

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^15.3.0",
     "react-infinite": "^0.9.2",
     "react-router": "^2.6.1",
-    "react-select": "1.0.0-beta14"
+    "react-select": "1.0.0-beta14",
+    "wolfy87-eventemitter": "^5.1.0"
   }
 }


### PR DESCRIPTION
Routes refactoring and use of a global Storage (that emits events when it changes)

Now we need only request per type (contacts, organizations, events, projects) when loading the related page for the first time.

And then all the items are constantly updated by websockets, and the search requests on the server are really light => only the ids are received.

Also, refactoring of selected items to mimic the same behaviour (and some renaming).
